### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Jochen Krapf
 maintainer=Jochen Krapf <jk@nerd2nerd.org>
 sentence=Library for Reading and Debouncing Mechanical Inputs Like Buttons, Switches and Encoders with Arduino-Based Controllers.
 paragraph=Library for Reading and Debouncing Mechanical Inputs Like Buttons, Switches and Encoders with Arduino-Based Controllers.
-category=Input
+category=Signal Input/Output
 url=https://github.com/jkDesignDE/MechInputs
 architectures=esp8266,avr


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Input' in library MechInputs is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format